### PR TITLE
适配 Typecho1.2.0

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -96,7 +96,7 @@ function themeConfig($form)
     $form->addInput($serviceworker);
 
     // 超高级设置
-    $advance = new Typecho_Widget_Helper_Form_Element_Textarea('advance', null, null, 超高级设置, '主题中包含一份 advanceSetting.sample.json，自己仿照着写吧。');
+    $advance = new Typecho_Widget_Helper_Form_Element_Textarea('advance', null, null, '超高级设置', '主题中包含一份 advanceSetting.sample.json，自己仿照着写吧。');
     $form->addInput($advance);
 }
 

--- a/libs/Comments.php
+++ b/libs/Comments.php
@@ -216,7 +216,7 @@ class VOID_Widget_Comments_Archive extends Widget_Abstract_Comments
      * @access protected
      * @return string
      */
-    protected function ___permalink()
+    protected function ___permalink() : string
     {
 
         if ($this->options->commentsPageBreak) {            
@@ -257,7 +257,7 @@ class VOID_Widget_Comments_Archive extends Widget_Abstract_Comments
      * @access protected
      * @return void
      */
-    protected function ___parentContent()
+    protected function ___parentContent() : ?array
     {
         return $this->parameter->parentContent;
     }
@@ -385,7 +385,7 @@ class VOID_Widget_Comments_Archive extends Widget_Abstract_Comments
      * @param array $value 每行的值
      * @return array
      */
-    public function push(array $value)
+    public function push(array $value) : array
     {
         $value = $this->filter($value);
         
@@ -526,7 +526,7 @@ class VOID_Widget_Comments_Archive extends Widget_Abstract_Comments
      * @access public
      * @return void
      */
-    public function alt()
+    public function alt(...$args)
     {
         $args = func_get_args();
         $num = func_num_args();

--- a/libs/Contents.php
+++ b/libs/Contents.php
@@ -18,7 +18,7 @@ Class Contents
     public static function getPost($cid)
     {
         $db = Typecho_Db::get();
-        $post = new Widget_Abstract_Contents(Typecho_Request::getInstance(), Typecho_Widget_Helper_Empty::getInstance());
+        $post = Widget_Abstract_Contents::alloc();
         $db->fetchRow($post->select()
             ->where("cid = ?", $cid)
             ->limit(1),
@@ -34,7 +34,7 @@ Class Contents
     public static function getComment($coid)
     {
         $db = Typecho_Db::get();
-        $comment = new Widget_Abstract_Comments(Typecho_Request::getInstance(), Typecho_Widget_Helper_Empty::getInstance());
+        $comment = Widget_Abstract_Comments::alloc();
         $db->fetchRow($comment->select()
             ->where("coid = ?", $coid)
             ->limit(1),
@@ -50,7 +50,7 @@ Class Contents
     public static function getMeta($mid)
     {
         $db = Typecho_Db::get();
-        $meta = new Widget_Abstract_Metas(Typecho_Request::getInstance(), Typecho_Widget_Helper_Empty::getInstance());
+        $meta = Widget_Abstract_Metas::alloc();
         $db->fetchRow($meta->select()
             ->where("mid = ?", $mid)
             ->limit(1),


### PR DESCRIPTION
对于 Typecho1.2.0 进行了部分适配工作，现在已经可以正常进入各级页面了。 

需要更新 VOID 插件以使用，已提交 PR，可以参考我的 [fork](https://github.com/TheFunny/VOID-Plugin)。

部分功能如懒加载 pjax 在我测试的情况下似乎不太正常？由于本人没学过 PHP 只能做到这一步了，望大佬能进行适配。