### PR TITLE
Update Comments.php

### DIFF
--- a/libs/Comments.php
+++ b/libs/Comments.php
@@ -192,10 +192,14 @@ class VOID_Widget_Comments_Archive extends Widget_Abstract_Comments
         $parentID=$parentID['parent'];
         if($parentID=='0') return '';
         else {
-            $author=$db->fetchRow($db->select()->from('table.comments')->where('coid = ?', $parentID));
-            if (!array_key_exists('author', $author) || empty($author['author']))
+            $author = $db->fetchRow($db->select()->from('table.comments')->where('coid = ?', $parentID));
+            if ($author === null) {
+                $author = array();
+            }
+            if (!array_key_exists('author', $author) || empty($author['author'])) {
                 $author['author'] = '已删除的评论';
-            return ' <span style="font-size: 0.9rem">回复</span> <b style="font-size:0.9rem;margin-right: 0.3em">@'.$author['author'].'</b> ';
+            }
+            return ' <span style="font-size: 0.9rem">回复</span> <b style="font-size:0.9rem;margin-right: 0.3em">@' . $author['author'] . '</b> ';
         }
     }  
 


### PR DESCRIPTION
如果有回复的父评论被删除，在 Typecho 1.2 中会报错
```
array_key_exists(): Argument #2 ($array) must be of type array, null given
```
我肯定是看不懂的，然后我拿去问 ChatGPT：
>这是一个 PHP 报错信息，表示在使用 array_key_exists() 函数时，第二个参数所传递的不是一个数组类型，而是一个 null 值。该函数通常用于检查一个数组中是否存在指定的键名。
>
>要解决这个问题，可以先判断第二个参数是否为 null 值，如果是，则需要将其赋值为一个空数组或者声明一个新的数组并传递给该函数。例如：
>```
>if ($array === null) {
>    $array = array();
>}
>```
>或者：
>```
>$array = $array ?? array();
>```
>这样就可以避免该错误信息的出现。

直接叫它修复，它是这么说的：

>这段代码判断与 $author 相关的键是否存在及其值是否为空，如果不存在则将 $author['author'] 的值设置为 "已删除的评论"。
>
>在上述代码中，使用了 array_key_exists() 函数来检查 $author 数组中是否存在 'author' 键。如果不存在，则将 $author['author'] 的值设置为 "已删除的评论"。
>
>为避免报错，您可以在使用 array_key_exists() 函数之前，添加一个判断，判断 $author 是否为 null 值，如果是，则创建一个空数组并给 $author 赋值，再执行判断。
>
>下面是修改后的代码：
>```
>else {
>    $author = $db->fetchRow($db->select()->from('table.comments')->where('coid = ?', $parentID));
>    if ($author === null) {
>        $author = array();
>    }
>    if (!array_key_exists('author', $author) || empty($author['author'])) {
>        $author['author'] = '已删除的评论';
>    }
>    return ' <span style="font-size: 0.9rem">回复</span> <b style="font-size:0.9rem;margin-right: >0.3em">@'.$author['author'].'</b> ';
>}
>```
>
>修改后代码添加了一个判断，如果 $author 的值为 null，则将其赋值为一个空数组，这样就避免了 array_key_exists() 函数报错。

然后就不报错了（
